### PR TITLE
implement compare for ion-js-cli test-driver

### DIFF
--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -116,11 +116,13 @@ export class IonComparisonReport {
     lhs: ComparisonContext;
     rhs: ComparisonContext;
     comparisonReportFile: WriteStream| NodeJS.WriteStream;
+    comparisonType: ComparisonType;
 
-    constructor(lhs: ComparisonContext, rhs: ComparisonContext, comparisonReportFile: WriteStream| NodeJS.WriteStream) {
+    constructor(lhs: ComparisonContext, rhs: ComparisonContext, comparisonReportFile: WriteStream| NodeJS.WriteStream, comprisonType: ComparisonType) {
         this.lhs = lhs;
         this.rhs = rhs;
         this.comparisonReportFile = comparisonReportFile;
+        this.comparisonType = comprisonType;
     }
 
     writeComparisonReport(result: ComparisonResultType, message: string, event_index_lhs: number, event_index_rhs: number) {

--- a/src/Compare.ts
+++ b/src/Compare.ts
@@ -1,0 +1,134 @@
+import fs from 'fs';
+import {OutputFormat} from './OutputFormat';
+import {IonEventStream} from "./IonEventStream";
+import {Writer} from "./IonWriter";
+import {ErrorType, IonCliError, IonCompareArgs} from "./Cli";
+import {IonTypes, makeReader, Reader} from "./Ion";
+
+/**
+ * The `command`, `describe`, and `handler` exports below are part of the yargs command module API
+ * See: https://github.com/yargs/yargs/blob/master/docs/advanced.md#providing-a-command-module
+ */
+export const command = 'compare <input-file..>'
+
+export const describe = "Compare all inputs (which may contain Ion streams and/or EventStreams) against all other inputs " +
+    "using the Ion data model's definition of equality. Write a ComparisonReport to the output.";
+
+export const builder = {
+    'comparison-type': {
+        alias: "y",
+        default: 'basic',
+        choices: ['basic', 'equivs', 'non-equivs', 'equivs_timeline'],
+        describe: "Comparison semantics to be used with the compare command, from the set (basic | equivs | non-equivs |" +
+            "equiv-timeline). Any embedded streams in the inputs are compared for EventStream equality. 'basic' performs" +
+            "a standard data-model comparison between the corresponding events (or embedded streams) in the inputs." +
+            "'equivs' verifies that each value (or embedded stream) in a top-level sequence is equivalent to every other" +
+            "value (or embedded stream) in that sequence. 'non-equivs' does the same, but verifies that the values (or" +
+            "embedded streams) are not equivalent. 'equiv-timeline' is the same as 'equivs', except that when top-level" +
+            "sequences contain timestamp values, they are considered equivalent if they represent the same instant" +
+            "regardless of whether they are considered equivalent by the Ion data model. [default: basic]"
+    }
+}
+
+export const handler = function (argv) {
+    let args = new IonCompareArgs(argv);
+    new Compare(args);
+}
+
+/** Comparison semantics to be used with compare command */
+export enum ComparisonType {
+    BASIC = "basic",
+    EQUIVS = "equivs",
+    NON_EQUIVS ="non_equivs",
+    EQUIVS_TIMELINE = "equivs_timeline"
+}
+
+/**
+ * ComparisonContext to create a structure for lhs and rhs streams
+ */
+export class ComparisonContext {
+    location: string;
+    eventStream: IonEventStream;
+
+    constructor(path: string, args: IonCompareArgs){
+        this.location = path;
+        let ionReader = this.createReadersForComparison(args);
+        this.setEventStream(ionReader, args);
+    }
+
+    createReadersForComparison(args: IonCompareArgs): Reader {
+        let ionReader;
+        try {
+            ionReader = makeReader(this.getInput(this.getLocation()));
+        } catch (Error) {
+            new IonCliError(ErrorType.READ, this.getLocation(), Error.message, args.getErrorReportFile()).writeErrorReport();
+        }
+        return ionReader;
+    }
+
+    getInput(path: string): string | Buffer {
+        let options = path.endsWith(".10n") ? null : "utf8";
+        return fs.readFileSync(path, options);
+    }
+
+    setEventStream(ionReader: Reader, args: IonCompareArgs) {
+        this.eventStream = new IonEventStream(ionReader, this.getLocation(), args);
+    }
+
+    getEventStream() {
+        return this.eventStream;
+    }
+
+    getLocation(): string {
+        return this.location;
+    }
+
+    writeComparisonContext(ionOutputWriter: Writer, isLHS: boolean, event_index: number) {
+        let field_name: string = isLHS ? "lhs" : "rhs";
+        ionOutputWriter.writeFieldName(field_name);
+        ionOutputWriter.stepIn(IonTypes.STRUCT);
+        ionOutputWriter.writeFieldName("location");
+        ionOutputWriter.writeString(this.location);
+        ionOutputWriter.writeFieldName("event");
+        this.getEventStream().getEvents()[event_index].write(ionOutputWriter);
+        ionOutputWriter.stepOut();
+        ionOutputWriter.writeFieldName("event_index");
+        ionOutputWriter.writeInt(event_index);
+    }
+}
+
+
+/**
+ * Compare all inputs (which may contain Ion streams and/or EventStreams) against all other inputs
+ * using the Ion data model's definition of equality. Write a ComparisonReport to the output.
+**/
+export class Compare {
+
+    constructor(parsedArgs: IonCompareArgs) {
+        let output_writer = OutputFormat.createIonWriter(parsedArgs.getOutputFormatName());
+        if (output_writer) {
+                this.compareFiles(output_writer, parsedArgs);
+        }
+    }
+
+    compareFiles(ionOutputWriter: Writer, args: IonCompareArgs): void {
+        for (let pathFirst of args.getInputFiles()) {
+            for(let pathSecond of args.getInputFiles()) {
+                if(pathFirst === pathSecond) {
+                    continue;
+                }
+                let comparisonType = args.getComparisonType();
+                if(comparisonType == ComparisonType.BASIC) {
+                    this.compareFilePair(ionOutputWriter, pathFirst, pathSecond, args);
+                }
+            }
+        }
+    }
+
+    compareFilePair(ionOutputWriter: Writer, pathFirst: string, pathSecond: string, args: IonCompareArgs): void {
+        let lhs = new ComparisonContext(pathFirst, args);
+        let rhs = new ComparisonContext(pathSecond, args);
+        ionOutputWriter.close();
+        lhs.getEventStream().equals(rhs.getEventStream(), lhs, rhs, args);
+    }
+}

--- a/src/Compare.ts
+++ b/src/Compare.ts
@@ -39,8 +39,8 @@ export const handler = function (argv) {
 export enum ComparisonType {
     BASIC = "basic",
     EQUIVS = "equivs",
-    NON_EQUIVS ="non_equivs",
-    EQUIVS_TIMELINE = "equivs_timeline"
+    NON_EQUIVS ="non-equivs",
+    EQUIV_TIMELINE = "equiv-timeline"
 }
 
 /**
@@ -113,12 +113,10 @@ export class Compare {
         for (let pathFirst of args.getInputFiles()) {
             for(let pathSecond of args.getInputFiles()) {
                 let comparisonType = args.getComparisonType();
-                if(comparisonType == ComparisonType.BASIC) {
-                    if(pathFirst === pathSecond) {
+                if(comparisonType == ComparisonType.BASIC && pathFirst === pathSecond) {
                         continue;
-                    }
-                    this.compareFilePair(ionOutputWriter, pathFirst, pathSecond, args);
                 }
+                this.compareFilePair(ionOutputWriter, pathFirst, pathSecond, args);
             }
         }
     }
@@ -127,7 +125,14 @@ export class Compare {
         let lhs = new ComparisonContext(pathFirst, args);
         let rhs = new ComparisonContext(pathSecond, args);
         ionOutputWriter.close();
-        let comparisonReport = new IonComparisonReport(lhs, rhs, args.getOutputFile());
-        lhs.getEventStream().compare(rhs.getEventStream(), comparisonReport);
+        let comparisonType = args.getComparisonType();
+        let comparisonReport = new IonComparisonReport(lhs, rhs, args.getOutputFile(), comparisonType);
+        if(comparisonType == ComparisonType.BASIC) {
+            lhs.getEventStream().compare(rhs.getEventStream(), comparisonReport);
+        }
+        else if(comparisonType == ComparisonType.EQUIVS || comparisonType == ComparisonType.EQUIV_TIMELINE
+            || comparisonType == ComparisonType.NON_EQUIVS) {
+            lhs.getEventStream().compareEquivs(rhs.getEventStream(), comparisonReport);
+        }
     }
 }

--- a/src/IonEvent.ts
+++ b/src/IonEvent.ts
@@ -24,6 +24,7 @@ import {BinaryWriter} from "./IonBinaryWriter";
 import {defaultLocalSymbolTable} from "./IonLocalSymbolTable";
 import {decodeUtf8} from "./IonUnicode";
 import JSBI from "jsbi";
+import {ComparisonResult, ComparisonResultType} from "./Cli";
 
 export enum IonEventType {
     SCALAR = 0,
@@ -45,6 +46,8 @@ export interface IonEvent {
     write(writer: Writer): void;
 
     equals(expected: IonEvent): boolean;
+
+    compare(expected: IonEvent): ComparisonResult;
 
     writeIonValue(writer: Writer): void;
 }
@@ -69,7 +72,7 @@ abstract class AbstractIonEvent implements IonEvent {
 
     abstract writeIonValue(writer: Writer): void;
 
-    abstract valueEquals(expected: IonEvent): boolean;
+    abstract valueCompare(expected: IonEvent): ComparisonResult;
 
     write(writer: Writer) {
         writer.stepIn(IonTypes.STRUCT);
@@ -164,23 +167,45 @@ abstract class AbstractIonEvent implements IonEvent {
     }
 
     equals(expected: IonEvent): boolean {
-        return (
-            this.eventType === expected.eventType &&
-            this.ionType === expected.ionType &&
-            this.fieldName === expected.fieldName &&
-            this.depth === expected.depth &&
-            this.annotationEquals(expected.annotations) &&
-            this.valueEquals(expected)
-        );
+        return this.compare(expected).result == ComparisonResultType.EQUAL;
     }
 
-    annotationEquals(expectedAnnotations: string[]): boolean {
-        if (this.annotations === expectedAnnotations) return true;
-        if (this.annotations.length !== expectedAnnotations.length) return false;
-        for (let i = 0; i < this.annotations.length; i++) {
-            if (this.annotations[i] !== expectedAnnotations[i]) return false;
+    /**
+     *  compares events for equivalence and generate comparison result
+     */
+    compare(expected: IonEvent): ComparisonResult {
+        if(this.eventType !== expected.eventType) {
+            return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Event types don't match");
         }
-        return true;
+        if(this.ionType !== expected.ionType) {
+            return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Ion types don't match");
+        }
+        if(this.fieldName !== expected.fieldName) {
+            return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Field names don't match "
+                + this.fieldName + " vs. " + expected.fieldName);
+        }
+        if(this.depth !== expected.depth) {
+            return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Event depths don't match "
+                + this.depth + " vs. " + expected.depth,);
+        }
+        let annotationResult = this.annotationCompare(expected.annotations);
+        if(annotationResult.result === ComparisonResultType.NOT_EQUAL) return annotationResult;
+        let valueResult = this.valueCompare(expected);
+        if(valueResult.result === ComparisonResultType.NOT_EQUAL) return valueResult;
+        return new ComparisonResult(ComparisonResultType.EQUAL);
+    }
+
+    annotationCompare(expectedAnnotations: string[]): ComparisonResult {
+        if (this.annotations === expectedAnnotations) return new ComparisonResult(ComparisonResultType.EQUAL);
+        if (this.annotations.length !== expectedAnnotations.length)
+            return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "annotations length don't match"
+                + this.annotations.length + " vs. " + expectedAnnotations.length);
+        for (let i = 0; i < this.annotations.length; i++) {
+            if (this.annotations[i] !== expectedAnnotations[i])
+                return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "annotation value doesn't match"
+                    + this.annotations[i] + " vs. " + expectedAnnotations[i]);
+        }
+        return new ComparisonResult(ComparisonResultType.EQUAL);
     }
 }
 
@@ -248,8 +273,10 @@ class IonNullEvent extends AbstractIonEvent {
         super(eventType, ionType, fieldName, annotations, depth, null);
     }
 
-    valueEquals(expected: IonNullEvent): boolean {
-        return expected instanceof IonNullEvent && this.ionValue === expected.ionValue;
+    valueCompare(expected: IonEvent): ComparisonResult {
+        if (expected instanceof IonNullEvent && this.ionValue === expected.ionValue)
+            return new ComparisonResult(ComparisonResultType.EQUAL);
+        return new ComparisonResult(ComparisonResultType.NOT_EQUAL, this.ionValue + " vs. " + expected.ionValue);
     }
 
     writeIonValue(writer: Writer): void {
@@ -263,8 +290,10 @@ class IonIntEvent extends AbstractIonEvent {
 
     }
 
-    valueEquals(expected: IonIntEvent): boolean {
-        return expected instanceof IonIntEvent && JSBI.equal(this.ionValue, expected.ionValue);
+    valueCompare(expected: IonEvent): ComparisonResult {
+        if (expected instanceof IonIntEvent && JSBI.equal(this.ionValue, expected.ionValue))
+            return new ComparisonResult(ComparisonResultType.EQUAL);
+        return new ComparisonResult(ComparisonResultType.NOT_EQUAL, this.ionValue + " vs. " + expected.ionValue);
     }
 
     writeIonValue(writer: Writer): void {
@@ -278,8 +307,10 @@ class IonBoolEvent extends AbstractIonEvent {
 
     }
 
-    valueEquals(expected: IonBoolEvent): boolean {
-        return expected instanceof IonBoolEvent && this.ionValue === expected.ionValue;
+    valueCompare(expected: IonEvent): ComparisonResult {
+        if (expected instanceof IonBoolEvent && this.ionValue === expected.ionValue)
+            return new ComparisonResult(ComparisonResultType.EQUAL);
+        return new ComparisonResult(ComparisonResultType.NOT_EQUAL, this.ionValue + " vs. " + expected.ionValue);
     }
 
     writeIonValue(writer: Writer): void {
@@ -293,9 +324,11 @@ class IonFloatEvent extends AbstractIonEvent {
 
     }
 
-    valueEquals(expected: IonFloatEvent): boolean {
-        if (isNaN(this.ionValue) && isNaN(expected.ionValue)) return true;
-        return expected instanceof IonFloatEvent && this.ionValue === expected.ionValue;
+    valueCompare(expected: IonEvent): ComparisonResult {
+        if (isNaN(this.ionValue) && isNaN(expected.ionValue)) return new ComparisonResult(ComparisonResultType.EQUAL);
+        if (expected instanceof IonFloatEvent && this.ionValue === expected.ionValue)
+            return new ComparisonResult(ComparisonResultType.EQUAL);
+        return new ComparisonResult(ComparisonResultType.NOT_EQUAL, this.ionValue + " vs. " + expected.ionValue);
     }
 
     writeIonValue(writer: Writer): void {
@@ -309,8 +342,10 @@ class IonDecimalEvent extends AbstractIonEvent {
 
     }
 
-    valueEquals(expected: IonDecimalEvent): boolean {
-        return expected instanceof IonDecimalEvent && this.ionValue.equals(expected.ionValue);
+    valueCompare(expected: IonEvent): ComparisonResult {
+        if (expected instanceof IonDecimalEvent && this.ionValue.equals(expected.ionValue))
+            return new ComparisonResult(ComparisonResultType.EQUAL);
+        return new ComparisonResult(ComparisonResultType.NOT_EQUAL, this.ionValue + " vs. " + expected.ionValue);
     }
 
     writeIonValue(writer: Writer): void {
@@ -324,10 +359,11 @@ class IonSymbolEvent extends AbstractIonEvent {
         super(eventType, ionType, fieldName, annotations, depth, ionValue);
     }
 
-    valueEquals(expected: IonSymbolEvent): boolean {
-        return expected instanceof IonSymbolEvent && this.ionValue === expected.ionValue;//will need to change when symboltokens are introduced.
+    valueCompare(expected: IonEvent): ComparisonResult {
+        if (expected instanceof IonSymbolEvent && this.ionValue === expected.ionValue)
+            return new ComparisonResult(ComparisonResultType.EQUAL);
+        return new ComparisonResult(ComparisonResultType.NOT_EQUAL, this.ionValue + " vs. " + expected.ionValue);
     }
-
     writeIonValue(writer: Writer): void {
         writer.writeSymbol(this.ionValue);//if symboltokens text is unknown we will need to write out symboltable
     }
@@ -340,8 +376,10 @@ class IonStringEvent extends AbstractIonEvent {
 
     }
 
-    valueEquals(expected: IonStringEvent): boolean {
-        return expected instanceof IonStringEvent && this.ionValue === expected.ionValue;
+    valueCompare(expected: IonEvent): ComparisonResult {
+        if (expected instanceof IonStringEvent && this.ionValue === expected.ionValue)
+            return new ComparisonResult(ComparisonResultType.EQUAL);
+        return new ComparisonResult(ComparisonResultType.NOT_EQUAL, this.ionValue + " vs. " + expected.ionValue);
     }
 
     writeIonValue(writer: Writer): void {
@@ -356,8 +394,10 @@ class IonTimestampEvent extends AbstractIonEvent {
 
     }
 
-    valueEquals(expected: IonTimestampEvent): boolean {
-        return expected instanceof IonTimestampEvent && this.ionValue.equals(expected.ionValue);
+    valueCompare(expected: IonEvent): ComparisonResult {
+        if (expected instanceof IonTimestampEvent && this.ionValue.equals(expected.ionValue))
+            return new ComparisonResult(ComparisonResultType.EQUAL);
+        return new ComparisonResult(ComparisonResultType.NOT_EQUAL, this.ionValue + " vs. " + expected.ionValue);
     }
 
     writeIonValue(writer: Writer): void {
@@ -370,13 +410,15 @@ class IonBlobEvent extends AbstractIonEvent {
         super(eventType, ionType, fieldName, annotations, depth, ionValue);
     }
 
-    valueEquals(expected: IonBlobEvent): boolean {
-        if (!(expected instanceof IonBlobEvent)) return false;
-        if (this.ionValue.length !== expected.ionValue.length) return false;
+    valueCompare(expected: IonEvent): ComparisonResult {
+        if (!(expected instanceof IonBlobEvent)) return new ComparisonResult(ComparisonResultType.NOT_EQUAL);
+        if (this.ionValue.length !== expected.ionValue.length)
+            return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Blob length don't match");
         for (let i = 0; i < this.ionValue.length; i++) {
-            if (this.ionValue[i] !== expected.ionValue[i]) return false;
+            if (this.ionValue[i] !== expected.ionValue[i])
+                return new ComparisonResult(ComparisonResultType.NOT_EQUAL, this.ionValue[i] + " vs. " + expected.ionValue[i]);
         }
-        return true;
+        return new ComparisonResult(ComparisonResultType.EQUAL);
     }
 
     writeIonValue(writer: Writer): void {
@@ -389,12 +431,13 @@ class IonClobEvent extends AbstractIonEvent {
         super(eventType, ionType, fieldName, annotations, depth, ionValue);
     }
 
-    valueEquals(expected: IonClobEvent): boolean {//can there be byte padding?
-        if (!(expected instanceof IonClobEvent)) return false;
+    valueCompare(expected: IonEvent): ComparisonResult {
+        if (!(expected instanceof IonClobEvent)) return new ComparisonResult(ComparisonResultType.NOT_EQUAL);
         for (let i = 0; i < this.ionValue.length; i++) {
-            if (this.ionValue[i] !== expected.ionValue[i]) return false;
+            if (this.ionValue[i] !== expected.ionValue[i])
+                return new ComparisonResult(ComparisonResultType.NOT_EQUAL, this.ionValue[i] + " vs. " + expected.ionValue[i]);
         }
-        return true;
+        return new ComparisonResult(ComparisonResultType.EQUAL);
     }
 
     writeIonValue(writer: Writer): void {
@@ -408,7 +451,7 @@ abstract class AbsIonContainerEvent extends AbstractIonEvent {
         super(eventType, ionType, fieldName, annotations, depth, null);
     }
 
-    abstract valueEquals(expected: AbsIonContainerEvent);
+    abstract valueCompare(expected: AbsIonContainerEvent);
 
     writeIonValue(writer: Writer): void {
         //no op;
@@ -422,30 +465,42 @@ class IonStructEvent extends AbsIonContainerEvent {//no embed support as of yet.
     }
 
     //two way equivalence between the structEvents, they must have the exact same number of equivalent elements.
-    valueEquals(expected: IonStructEvent): boolean {
-        return expected instanceof IonStructEvent && this.ionValue.length === expected.ionValue.length && this.structsEqual(this.ionValue, expected.ionValue);
+    valueCompare(expected: IonStructEvent): ComparisonResult {
+        if(!(expected instanceof IonStructEvent)) {
+            return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Event types don't match", );
+        }
+        if(this.ionValue.length !== expected.ionValue.length)
+            return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Struct length don't match");
+        return this.structsCompare(this.ionValue, expected.ionValue);
     }
 
     //for each actual ionEvent, searches for an equivalent expected ionEvent,
     //equivalent pairings remove the paired expectedEvent from the search space.
-    structsEqual(actualEvents: AbstractIonEvent[], expectedEvents: AbstractIonEvent[]): boolean {
-        let matchFound: boolean = true;
+    structsCompare(actualEvents: AbstractIonEvent[], expectedEvents: AbstractIonEvent[]): ComparisonResult {
+        let matchFound:  ComparisonResult = new ComparisonResult(ComparisonResultType.EQUAL);
         let paired: boolean[] = new Array<boolean>(expectedEvents.length);
         for (let i: number = 0; matchFound && i < actualEvents.length; i++) {
-            matchFound = false;
-            for (let j: number = 0; !matchFound && j < expectedEvents.length; j++) {
+            matchFound.result = ComparisonResultType.NOT_EQUAL;
+            for (let j: number = 0; matchFound.result == ComparisonResultType.NOT_EQUAL && j < expectedEvents.length; j++) {
                 if (!paired[j]) {
                     let child = actualEvents[i];
                     let expectedChild = expectedEvents[j];
-                    matchFound = child.equals(expectedChild);
-                    if (matchFound) paired[j] = true;
-                    if (matchFound && child.eventType === IonEventType.CONTAINER_START) {
+                    matchFound = child.compare(expectedChild);
+                    if (matchFound.result == ComparisonResultType.EQUAL) paired[j] = true;
+                    if (matchFound.result == ComparisonResultType.EQUAL && child.eventType === IonEventType.CONTAINER_START) {
                         for (let k = j + 1; k < expectedChild.ionValue.length; k++) {
                             paired[k] = true;
                         }
                         i += child.ionValue.length;
                     }
                 }
+            }
+        }
+        // set matchFound to the first pair that didn't find a matching field if any
+        for(let i: number = 0; i < paired.length; i++) {
+            if(!paired[i]) {
+                matchFound = new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Didn't find matching field for " + expectedEvents[i].fieldName);
+                break;
             }
         }
         return matchFound;
@@ -459,20 +514,21 @@ class IonListEvent extends AbsIonContainerEvent {
 
     }
 
-    valueEquals(expected: IonListEvent): boolean {
-        if (!(expected instanceof IonListEvent)) return false;
+    valueCompare(expected: IonListEvent): ComparisonResult {
+        if (!(expected instanceof IonListEvent)) return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Event types don't match");
         let container = this.ionValue;
         let expectedContainer = expected.ionValue;
-        if (container.length !== expectedContainer.length) return false;
+        if (container.length !== expectedContainer.length) return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "List length don't match");
         for (let i: number = 0; i < container.length; i++) {
             let child = container[i];
-            if (!child.equals(expectedContainer[i])) {
-                return false;
+            if (child.compare(expectedContainer[i]).result == ComparisonResultType.NOT_EQUAL) {
+                return new ComparisonResult(ComparisonResultType.NOT_EQUAL, child.ionValue + " vs. " +
+                    expectedContainer[i].ionValue, i + 1, i + 1);
             } else if (child.eventType === IonEventType.CONTAINER_START) {
                 i += child.ionValue.length;
             }
         }
-        return true;
+        return new ComparisonResult(ComparisonResultType.EQUAL);
     }
 }
 
@@ -482,20 +538,20 @@ class IonSexpEvent extends AbsIonContainerEvent {
 
     }
 
-    valueEquals(expected: IonSexpEvent): boolean {
-        if (!(expected instanceof IonSexpEvent)) return false;
+    valueCompare(expected: IonSexpEvent): ComparisonResult {
+        if (!(expected instanceof IonSexpEvent)) return new ComparisonResult(ComparisonResultType.NOT_EQUAL,"Event types don't match");
         let container = this.ionValue;
         let expectedContainer = expected.ionValue;
-        if (container.length !== expectedContainer.length) return false;
+        if (container.length !== expectedContainer.length) return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "S-expression length don't match");
         for (let i: number = 0; i < container.length; i++) {
             let child = container[i];
-            if (!child.equals(expectedContainer[i])) {
-                return false;
+            if (child.compare(expectedContainer[i]).result == ComparisonResultType.NOT_EQUAL) {
+                return child.compare(expectedContainer[i]);
             } else if (child.eventType === IonEventType.CONTAINER_START) {
                 i += child.ionValue.length;
             }
         }
-        return true;
+        return new ComparisonResult(ComparisonResultType.EQUAL);
     }
 }
 
@@ -505,9 +561,12 @@ class IonEndEvent extends AbstractIonEvent {
 
     }
 
-    valueEquals(expected: IonEndEvent) {
-        return expected instanceof IonEndEvent
-            && this.ionValue === expected.ionValue; //should be null === null if they are both end events.
+    valueCompare(expected: IonEndEvent): ComparisonResult {
+        //should be null === null if they are both end events.
+        if(expected instanceof IonEndEvent && this.ionValue === expected.ionValue) {
+            return new ComparisonResult(ComparisonResultType.EQUAL);
+        }
+        return new ComparisonResult(ComparisonResultType.NOT_EQUAL, this.ionValue + " vs. " + expected.ionValue);
     }
 
     writeIonValue(writer: Writer): void {

--- a/src/IonEvent.ts
+++ b/src/IonEvent.ts
@@ -545,8 +545,9 @@ class IonSexpEvent extends AbsIonContainerEvent {
         if (container.length !== expectedContainer.length) return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "S-expression length don't match");
         for (let i: number = 0; i < container.length; i++) {
             let child = container[i];
-            if (child.compare(expectedContainer[i]).result == ComparisonResultType.NOT_EQUAL) {
-                return child.compare(expectedContainer[i]);
+            let eventResult = child.compare(expectedContainer[i]).result;
+            if (eventResult == ComparisonResultType.NOT_EQUAL) {
+                return eventResult;
             } else if (child.eventType === IonEventType.CONTAINER_START) {
                 i += child.ionValue.length;
             }

--- a/src/IonEvent.ts
+++ b/src/IonEvent.ts
@@ -178,7 +178,8 @@ abstract class AbstractIonEvent implements IonEvent {
             return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Event types don't match");
         }
         if(this.ionType !== expected.ionType) {
-            return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Ion types don't match");
+            return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Ion types don't match "
+                + this.ionType?.name + " vs. " + expected.ionType?.name);
         }
         if(this.fieldName !== expected.fieldName) {
             return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Field names don't match "

--- a/src/IonEventStream.ts
+++ b/src/IonEventStream.ts
@@ -29,6 +29,7 @@ import {
     IonCliError,
     IonComparisonReport
 } from "./Cli";
+import {ComparisonType} from "./Compare";
 
 export class IonEventStream {
     private eventStream: IonEvent[];
@@ -187,6 +188,76 @@ export class IonEventStream {
             expectedIndex++;
         }
         return new ComparisonResult(ComparisonResultType.EQUAL);
+    }
+
+    compareEquivs(expected: IonEventStream, comparisonReport: IonComparisonReport): ComparisonResult {
+        let actualIndex: number = 0;
+        let expectedIndex: number = 0;
+        let comparisonType = comparisonReport.comparisonType;
+        while (actualIndex < this.eventStream.length && expectedIndex < expected.eventStream.length) {
+            let actualEvent = this.eventStream[actualIndex];
+            let expectedEvent = expected.eventStream[expectedIndex];
+
+            if(actualEvent.eventType == IonEventType.STREAM_END && expectedEvent.eventType == IonEventType.STREAM_END) {
+                break;
+            } else if(actualEvent.eventType == IonEventType.STREAM_END || expectedEvent.eventType == IonEventType.STREAM_END) {
+                comparisonReport.writeComparisonReport(ComparisonResultType.ERROR,
+                    "Different number of comparison sets.", actualIndex, expectedIndex);
+                return new ComparisonResult(ComparisonResultType.ERROR);
+            } else if (!(actualEvent.ionType == IonTypes.LIST || actualEvent.ionType == IonTypes.SEXP)
+                || !(expectedEvent.ionType == IonTypes.LIST || expectedEvent.ionType == IonTypes.SEXP)) {
+                throw new Error("Comparison sets must be lists or s-expressions.");
+            } else if(this.isEmbedded as any ^ expected.isEmbedded as any) {
+                throw new Error("Both streams should be embedded streams.");
+            }
+
+            let actualContainer: IonEvent[] = this.eventStream[actualIndex].ionValue;
+            let expectedContainer: IonEvent[] = expected.eventStream[expectedIndex].ionValue;
+
+            actualIndex = actualIndex + actualEvent.ionValue.length;
+            expectedIndex = expectedIndex + expectedEvent.ionValue.length;
+
+            for (let i = 0; i < actualContainer.length; i++) {
+                for (let j = 0; j < expectedContainer.length; j++) {
+                    // for non-equivs: not comparing same index's value as it will always be same.
+                    if (comparisonType == ComparisonType.NON_EQUIVS && i == j)
+                        continue;
+                    let actualContainerEvent: IonEvent = actualContainer[i];
+                    let expectedContainerEvent: IonEvent = expectedContainer[j];
+                    if(actualContainerEvent.eventType == IonEventType.STREAM_END || actualContainerEvent.eventType == IonEventType.CONTAINER_END) {
+                        // no op
+                        break;
+                    }
+                    if (expectedContainerEvent.eventType == IonEventType.STREAM_END || expectedContainerEvent.eventType == IonEventType.CONTAINER_END) {
+                        // no op
+                        continue;
+                    }
+
+                    let eventResult;
+
+                    if (comparisonType == ComparisonType.EQUIV_TIMELINE && actualContainerEvent.ionType == IonTypes.TIMESTAMP) {
+                        let ionTimestampActual = actualContainerEvent.ionValue;
+                        let ionTimestampExpected = expectedContainerEvent.ionValue;
+                        eventResult = ionTimestampActual.compareTo(ionTimestampExpected) == 0 ? new ComparisonResult(ComparisonResultType.EQUAL)
+                            : new ComparisonResult(ComparisonResultType.NOT_EQUAL, ionTimestampActual + " vs. " + ionTimestampExpected);
+                    } else {
+                         eventResult = actualContainerEvent.compare(expectedContainerEvent);
+                    }
+
+                    if ((comparisonType == ComparisonType.EQUIVS || comparisonType == ComparisonType.EQUIV_TIMELINE)
+                        && eventResult.result == ComparisonResultType.NOT_EQUAL) {
+                        comparisonReport.writeComparisonReport(ComparisonResultType.NOT_EQUAL, eventResult.message, i + 1, j + 1);
+                        return new ComparisonResult(ComparisonResultType.NOT_EQUAL);
+                    } else if (comparisonType == ComparisonType.NON_EQUIVS && eventResult.result == ComparisonResultType.EQUAL) {
+                        comparisonReport.writeComparisonReport(ComparisonResultType.EQUAL, "Both values are equal in non-equivs comparison.", i + 1, j + 1);
+                        return new ComparisonResult(ComparisonResultType.EQUAL);
+                    }
+                }
+            }
+            actualIndex++;
+            expectedIndex++;
+        }
+        return new ComparisonResult(comparisonType == ComparisonType.EQUIVS ? ComparisonResultType.EQUAL : ComparisonResultType.NOT_EQUAL);
     }
 
     private generateStream(path: string, args: IonCliCommonArgs): void {


### PR DESCRIPTION
**Description:**

As part of ion-test-driver, this commit is for ion-js-cli compare. It supports:

 - --output(-o) : rewrite given input files to specified output format
 - --output-fomrat(-f): specify ion output format
 - --error-report(-e): generate error report to specified location 
- --comparison-type(-y): comparison semantics to be used with compare command

**Completeted Tasks:**

1. Implement comparisonContext
2. Implement comprisonReport
3. comparison using event stream equals method
4. currently comparisonReport prints only basic comparison for SCALAR events.

**TO DO:**

- [ ] Support comparisonReport for basic comparison of LIST, SEXP and STRUCT event type.
- [ ] Support equivs and non_equivs comparison 

**Test:**

tested using multiple input files for comparison (binary, text, pretty, events).
e.g. ts-node compare example1.ion example2.ion --output comparison_report 