### PR TITLE
Implement equivs and non-equivs comparison

### DIFF
--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -116,11 +116,13 @@ export class IonComparisonReport {
     lhs: ComparisonContext;
     rhs: ComparisonContext;
     comparisonReportFile: WriteStream| NodeJS.WriteStream;
+    comparisonType: ComparisonType;
 
-    constructor(lhs: ComparisonContext, rhs: ComparisonContext, comparisonReportFile: WriteStream| NodeJS.WriteStream) {
+    constructor(lhs: ComparisonContext, rhs: ComparisonContext, comparisonReportFile: WriteStream| NodeJS.WriteStream, comprisonType: ComparisonType) {
         this.lhs = lhs;
         this.rhs = rhs;
         this.comparisonReportFile = comparisonReportFile;
+        this.comparisonType = comprisonType;
     }
 
     writeComparisonReport(result: ComparisonResultType, message: string, event_index_lhs: number, event_index_rhs: number) {

--- a/src/Compare.ts
+++ b/src/Compare.ts
@@ -40,7 +40,7 @@ export enum ComparisonType {
     BASIC = "basic",
     EQUIVS = "equivs",
     NON_EQUIVS ="non-equivs",
-    EQUIVS_TIMELINE = "equivs-timeline"
+    EQUIV_TIMELINE = "equiv-timeline"
 }
 
 /**
@@ -130,7 +130,7 @@ export class Compare {
         if(comparisonType == ComparisonType.BASIC) {
             lhs.getEventStream().compare(rhs.getEventStream(), comparisonReport);
         }
-        else if(comparisonType == ComparisonType.EQUIVS || comparisonType == ComparisonType.EQUIVS_TIMELINE
+        else if(comparisonType == ComparisonType.EQUIVS || comparisonType == ComparisonType.EQUIV_TIMELINE
             || comparisonType == ComparisonType.NON_EQUIVS) {
             lhs.getEventStream().compareEquivs(rhs.getEventStream(), comparisonReport);
         }

--- a/src/Compare.ts
+++ b/src/Compare.ts
@@ -39,8 +39,8 @@ export const handler = function (argv) {
 export enum ComparisonType {
     BASIC = "basic",
     EQUIVS = "equivs",
-    NON_EQUIVS ="non_equivs",
-    EQUIVS_TIMELINE = "equivs_timeline"
+    NON_EQUIVS ="non-equivs",
+    EQUIVS_TIMELINE = "equivs-timeline"
 }
 
 /**
@@ -113,12 +113,10 @@ export class Compare {
         for (let pathFirst of args.getInputFiles()) {
             for(let pathSecond of args.getInputFiles()) {
                 let comparisonType = args.getComparisonType();
-                if(comparisonType == ComparisonType.BASIC) {
-                    if(pathFirst === pathSecond) {
+                if(comparisonType == ComparisonType.BASIC && pathFirst === pathSecond) {
                         continue;
-                    }
-                    this.compareFilePair(ionOutputWriter, pathFirst, pathSecond, args);
                 }
+                this.compareFilePair(ionOutputWriter, pathFirst, pathSecond, args);
             }
         }
     }
@@ -127,7 +125,14 @@ export class Compare {
         let lhs = new ComparisonContext(pathFirst, args);
         let rhs = new ComparisonContext(pathSecond, args);
         ionOutputWriter.close();
-        let comparisonReport = new IonComparisonReport(lhs, rhs, args.getOutputFile());
-        lhs.getEventStream().compare(rhs.getEventStream(), comparisonReport);
+        let comparisonType = args.getComparisonType();
+        let comparisonReport = new IonComparisonReport(lhs, rhs, args.getOutputFile(), comparisonType);
+        if(comparisonType == ComparisonType.BASIC) {
+            lhs.getEventStream().compare(rhs.getEventStream(), comparisonReport);
+        }
+        else if(comparisonType == ComparisonType.EQUIVS || comparisonType == ComparisonType.EQUIVS_TIMELINE
+            || comparisonType == ComparisonType.NON_EQUIVS) {
+            lhs.getEventStream().compareEquivs(rhs.getEventStream(), comparisonReport);
+        }
     }
 }

--- a/src/IonEvent.ts
+++ b/src/IonEvent.ts
@@ -178,7 +178,8 @@ abstract class AbstractIonEvent implements IonEvent {
             return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Event types don't match");
         }
         if(this.ionType !== expected.ionType) {
-            return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Ion types don't match");
+            return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Ion types don't match "
+                + this.ionType?.name + " vs. " + expected.ionType?.name);
         }
         if(this.fieldName !== expected.fieldName) {
             return new ComparisonResult(ComparisonResultType.NOT_EQUAL, "Field names don't match "

--- a/src/IonEventStream.ts
+++ b/src/IonEventStream.ts
@@ -211,11 +211,8 @@ export class IonEventStream {
                 throw new Error("Both streams should be embedded streams.");
             }
 
-            let actualContainer: IonEvent[];
-            let expectedContainer: IonEvent[];
-
-            actualContainer = this.eventStream[actualIndex].ionValue;
-            expectedContainer = expected.eventStream[expectedIndex].ionValue;
+            let actualContainer: IonEvent[] = this.eventStream[actualIndex].ionValue;
+            let expectedContainer: IonEvent[] = expected.eventStream[expectedIndex].ionValue;
 
             actualIndex = actualIndex + actualEvent.ionValue.length;
             expectedIndex = expectedIndex + expectedEvent.ionValue.length;
@@ -235,7 +232,18 @@ export class IonEventStream {
                         // no op
                         continue;
                     }
-                    let eventResult = actualContainerEvent.compare(expectedContainerEvent);
+
+                    let eventResult;
+
+                    if (comparisonType == ComparisonType.EQUIV_TIMELINE && actualContainerEvent.ionType == IonTypes.TIMESTAMP) {
+                        let ionTimestampFirst = actualContainerEvent.ionValue;
+                        let ionTimestampSecond = expectedContainerEvent.ionValue;
+                        eventResult = ionTimestampFirst.equals(ionTimestampSecond) ? new ComparisonResult(ComparisonResultType.EQUAL)
+                            : new ComparisonResult(ComparisonResultType.NOT_EQUAL);
+                    } else {
+                         eventResult = actualContainerEvent.compare(expectedContainerEvent);
+                    }
+
                     if (comparisonType == ComparisonType.EQUIVS && eventResult.result == ComparisonResultType.NOT_EQUAL) {
                         comparisonReport.writeComparisonReport(ComparisonResultType.NOT_EQUAL, eventResult.message, i + 1, j + 1);
                         return new ComparisonResult(ComparisonResultType.NOT_EQUAL);

--- a/src/IonEventStream.ts
+++ b/src/IonEventStream.ts
@@ -236,15 +236,16 @@ export class IonEventStream {
                     let eventResult;
 
                     if (comparisonType == ComparisonType.EQUIV_TIMELINE && actualContainerEvent.ionType == IonTypes.TIMESTAMP) {
-                        let ionTimestampFirst = actualContainerEvent.ionValue;
-                        let ionTimestampSecond = expectedContainerEvent.ionValue;
-                        eventResult = ionTimestampFirst.equals(ionTimestampSecond) ? new ComparisonResult(ComparisonResultType.EQUAL)
-                            : new ComparisonResult(ComparisonResultType.NOT_EQUAL);
+                        let ionTimestampActual = actualContainerEvent.ionValue;
+                        let ionTimestampExpected = expectedContainerEvent.ionValue;
+                        eventResult = ionTimestampActual.compareTo(ionTimestampExpected) == 0 ? new ComparisonResult(ComparisonResultType.EQUAL)
+                            : new ComparisonResult(ComparisonResultType.NOT_EQUAL, ionTimestampActual + " vs. " + ionTimestampExpected);
                     } else {
                          eventResult = actualContainerEvent.compare(expectedContainerEvent);
                     }
 
-                    if (comparisonType == ComparisonType.EQUIVS && eventResult.result == ComparisonResultType.NOT_EQUAL) {
+                    if ((comparisonType == ComparisonType.EQUIVS || comparisonType == ComparisonType.EQUIV_TIMELINE)
+                        && eventResult.result == ComparisonResultType.NOT_EQUAL) {
                         comparisonReport.writeComparisonReport(ComparisonResultType.NOT_EQUAL, eventResult.message, i + 1, j + 1);
                         return new ComparisonResult(ComparisonResultType.NOT_EQUAL);
                     } else if (comparisonType == ComparisonType.NON_EQUIVS && eventResult.result == ComparisonResultType.EQUAL) {


### PR DESCRIPTION
**Description:**

As part of ion-test-driver, this PR is for ion-js-cli compare equivs, non-equivs and equivs-timeline modes. 
 
**Completeted Tasks:**

- add comparisonType to `IonComparisonReport`
- Implement `compareEquivs` method.
  - throws error if not LIST or SEXP.
  - 'equivs' verifies that each value (or embedded stream) in a top-level sequence is equivalent to every other value (or embedded stream) in that sequence.
  - 'non-equivs' does the same, but verifies that the values (or embedded streams) are not equivalent. 

**TO DO:**

1. Support equivs-timeline comparison.

**Test:**

tested using multiple input files for equivs and non-equivs comparison.
e.g. ts-node compare example1.ion  example2.ion --output output.ion --comparison-type equips
